### PR TITLE
Remove unused routes from authentication generator

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   get "admin" => "admin#index"
   resources :users
-  resource :session
-  resources :passwords, param: :token
+  resource :session, only: %i[ new create destroy ]
+  resources :passwords, except: %i[ index show destroy ], param: :token
   resources :orders
   resources :line_items
   resources :carts


### PR DESCRIPTION
When you run bin/rails generate authentication, the generator creates a `resource` route for `sessions` and a `resources` route for passwords. The generated controllers only implement a subset of the needed resource routes.

Modify the `config/routes.rb` configuration so that the unused routes are removed and the `bin/rails routes --unused` command returns zero results.

After resolving, investigate whether issue has been addressed in the Rails repo itself and submit a pull request there if needed.

Resolves:
Unused routes created by authentication generator #22